### PR TITLE
Make the Android back button close the game when in TitleState

### DIFF
--- a/source/funkin/ui/title/TitleState.hx
+++ b/source/funkin/ui/title/TitleState.hx
@@ -228,11 +228,11 @@ class TitleState extends MusicBeatState
   {
     FlxG.bitmapLog.add(FlxG.camera.buffer);
 
-    #if desktop
+    #if (desktop || android)
     // Pressing BACK on the title screen should close the game.
     // This lets you exit without leaving fullscreen mode.
-    // Only applicable on desktop.
-    if (controls.BACK)
+    // Only applicable on desktop and Android.
+    if (#if android FlxG.android.justReleased.BACK || #end controls.BACK)
     {
       openfl.Lib.application.window.close();
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
